### PR TITLE
map: fixed nodes not showing

### DIFF
--- a/nodewatcher/modules/frontend/map/static/map/js/code.js
+++ b/nodewatcher/modules/frontend/map/static/map/js/code.js
@@ -48,7 +48,7 @@
             var streamId = data.objects[0].id;
             var latestTimestamp = moment(data.objects[0].latest_datapoint).unix();
             $.ajax({
-                'url': "/api/v1/stream/" + streamId + "/?format=json&reverse=true&limit=1&start=" + latestTimestamp,
+                'url': "/api/v1/stream/" + streamId + "/?format=json&limit=1&start=" + latestTimestamp,
             }).done(function(data) {
                 var graph = data.datapoints[0].v;
                 var nodes = [];


### PR DESCRIPTION
Fixes the InfluxDB related reverse query error.
It has been forbidden to use since InfluxDB 1.4